### PR TITLE
Fix: Respect console setting in PlatformIO Terminal

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -91,7 +91,8 @@ const HydrogenLauncher = {
     const connectionFile = this.getConnectionFile();
     if (!connectionFile) return;
 
-    term.getConnectionCommand(connectionFile, (err, command) => {
+    const jpConsole = atom.config.get('hydrogen-launcher.console');
+    term.getConnectionCommand(connectionFile, jpConsole, (err, command) => {
       if (!this.platformIoTerminal) {
         atom.notifications.addError('PlatformIO IDE Terminal has to be installed.');
       } else if (err) {


### PR DESCRIPTION
This should fix #16 

@dhhagan I don't have `qtconsole` installed. Would you be able to test this branch?